### PR TITLE
prevent replacing *-orig files that cause recursive calls

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,8 +45,16 @@ chmod +x /opt/xensource/sm/RBDSR.py
 chmod +x /opt/xensource/sm/cephutils.py
 ln -s /opt/xensource/sm/RBDSR.py /opt/xensource/sm/RBDSR
 
-mv /sbin/tap-ctl /sbin/tap-ctl-orig
-mv /bin/vhd-tool /bin/vhd-tool-orig
+if [ -e /sbin/tap-ctl-orig ] then
+  echo "tap-ctl-orig already in place, not backing up!"
+else
+  mv /sbin/tap-ctl /sbin/tap-ctl-orig
+fi
+if [ -e /bin/vhd-tool-orig ] then
+  echo "/bin/vhd-tool-orig already in place, not backing up!"
+else
+  mv /bin/vhd-tool /bin/vhd-tool-orig
+fi
 cp bins/tap-ctl /sbin/tap-ctl
 cp bins/vhd-tool /bin/vhd-tool
 chmod +x /sbin/tap-ctl


### PR DESCRIPTION
Because the installation of packages did not pass because of low memory in /var/log i ran the install script twice. Shortly afterwards XenServer OOM features seemed to kill xapi and other necessary processes. It took me a while to realise that install.sh copied tap-ctl to tap-ctl-orig the first try i ran it.
The second time it copied tap-ctl to tap-ctl-orig again, deleting the binary file (original). The tap-ctl-orig now calls itself endlessly which causes a forkbomb to appear in dom0
PR addresses this issue by checking the existence of tap-ctl-orig and vhd-tool-orig and only backing them up if they are non-existent.