### PR TITLE
Changed installation routine to easily change ceph version and make d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,44 @@
 # RBDSR - XenServer Storage Manager plugin for CEPH
 This plugin adds support of Ceph block devices into XenServer.
-It supports creation of VDI as RBD device in Ceph pool. 
+It supports creation of VDI as RBD device in Ceph pool.
 It uses Ceph snapshots and clones to handle VDI snapshots. It also supports Xapi Storage Migration (XSM) and XenServer High Availability (HA).
 
 You can change the following device configs using device-config args when creating PBDs on each hosts:
 - cephx-id: the cephx user id to be used. Default is admin for the client.admin user.
 - rbd-mode: can be kernel, fuse or nbd. Default is nbd.
 
-## Installation 
+## Installation
 
-This plugin uses **rbd**, **rbd-nbd** add **rbd-fuse** utilities for manipulating RBD devices, so you need to install ceph-common, rbd-nbd and rbd-fuse packages from ceph repository on your XenServer hosts.
+This plugin uses **rbd**, **rbd-nbd** add **rbd-fuse** utilities for manipulating RBD devices, so the install script will install ceph-common, rbd-nbd and rbd-fuse packages from ceph repository on your XenServer hosts.
 
 1. Run this command:
 
-		sh <(curl -s https://raw.githubusercontent.com/rposudnevskiy/RBDSR/master/netinstall.sh)
+		# sh <(curl -s https://raw.githubusercontent.com/rposudnevskiy/RBDSR/master/netinstall.sh)
+		# ./install.sh install jewel
 
 2. Create ```/etc/ceph/ceph.conf``` accordingly you Ceph cluster. The easiest way is just copy it from your Ceph cluster node
 
-3. Copy ```/etc/ceph/ceph.client.admin.keyring``` to XenServer hosts from your Ceph cluster node. 
+3. Copy ```/etc/ceph/ceph.client.admin.keyring``` to XenServer hosts from your Ceph cluster node.
 
 4. Restart XAPI tool-stack on XenServer hosts
 
-		# xe-toolstack-restart 
+		# xe-toolstack-restart
+
+## Removal
+		1. Remove all Ceph RBD SR out of XenServer with the appropriate commands.
+
+		2. Run this command:
+
+				# ~/RDBSR/install.sh deinstall jewel
+
+		3. Restart XAPI tool-stack on XenServer hosts
+
+				# xe-toolstack-restart
 
 
 ## Usage
 
-1. Create a pool on your Ceph cluster to store VDI images (should be executed on Ceph cluster node):
+1. Create a pool on your Ceph cluster to store VDI images (should be executed on Ceph cluster node). The naming convention RBD_XenStorage-<uuid> is important!:
 
 		# uuidgen
 		4ceb0f8a-1539-40a4-bee2-450a025b04e1
@@ -36,7 +48,7 @@ This plugin uses **rbd**, **rbd-nbd** add **rbd-fuse** utilities for manipulatin
 2. Introduce the pool created in previous step as Storage Repository on XenServer hosts:
 
 		  xe sr-introduce name-label="CEPH RBD Storage" type=rbd uuid=4ceb0f8a-1539-40a4-bee2-450a025b04e1 shared=true content-type=user
-		
+
 3. Run the ```xe host-list``` command to find out the host UUID for Xenserer host:
 
 		# xe host-list
@@ -50,12 +62,12 @@ This plugin uses **rbd**, **rbd-nbd** add **rbd-fuse** utilities for manipulatin
 		aec2c6fc-e1fb-0a27-2437-9862cffe213e
 
 	If you would like to use a different cephx user or rbd mode, use the follwing device-config:
-		
+
 		# xe pbd-create sr-uuid=4ceb0f8a-1539-40a4-bee2-450a025b04e1 host-uuid=83f2c775-57fc-457b-9f98-2b9b0a7dbcb5 device-config:cephx-id=xenserver device-config:rbd-mode=kernel
-		
+
 
 5. Attach the PBD created with xe pbd-plug command:
 
 		# xe pbd-plug uuid=aec2c6fc-e1fb-0a27-2437-9862cffe213e
-		
+
 	The SR should be connected to the XenServer hosts and be visible in XenCenter.

--- a/install.sh
+++ b/install.sh
@@ -1,80 +1,139 @@
 #!/bin/bash
 CEPH_VERSION="luminous"
-echo "****************"
-echo "Install RBDSR plugin"
-echo "****************"
 
-echo "Install new Repos"
-cp -n repos/ceph-$CEPH_VERSION.repo /etc/yum.repos.d/
+# Usage: installRepo <ceph-version>
+function installRepo {
+  echo "Install the release.asc key"
+  rpm --import 'https://download.ceph.com/keys/release.asc'
+  echo "Install new Repos"
+  cp -n repos/ceph-$1.repo /etc/yum.repos.d/
+}
 
-echo "Install the release.asc key"
-rpm --import 'https://download.ceph.com/keys/release.asc'
+# Usage: removeRepo <ceph-version>
+function removeRepo {
+  rm -f /etc/yum.repos.d/
+}
 
-echo "Fix Repo Path and Enable"
-sed -ie 's/\$releasever/7/g' /etc/yum.repos.d/CentOS-Base.repo
-sed -ie '/\[base\]/,/^\[/s/enabled=0/enabled=1/' /etc/yum.repos.d/CentOS-Base.repo
-sed -ie '/\[updates\]/,/^\[/s/enabled=0/enabled=1/' /etc/yum.repos.d/CentOS-Base.repo
-sed -ie '/\[extras\]/,/^\[/s/enabled=0/enabled=1/' /etc/yum.repos.d/CentOS-Base.repo
+# Usage: setReposEnabled <repo filename> <section name> <0|1>
+function setReposEnabled {
+  echo "Set $1 $2 enabled = $3"
+  sed -ie '/\[$2\]/,/^\[/s/enabled=[01]/enabled=$3/' /etc/yum.repos.d/$1
+}
 
-echo "Install Required Packages"
-yum install -y epel-release
-yum install -y yum-plugin-priorities.noarch
+# Usage: backupFile <path>
+function backupFile {
+  echo "Backing Up file $1"
+  if [ -e $1-orig ]; then
+    echo "$1-orig already in place, not backing up!"
+  else
+    mv $1 $1-orig
+  fi
+}
 
-sed -ie 's/enabled=0/enabled=1/g' /etc/yum.repos.d/epel.repo
-yum install -y snappy leveldb gdisk python-argparse gperftools-libs
-yum install -y fuse fuse-libs
-yum install -y ceph-common rbd-fuse rbd-nbd
+# Usage: copyFile <source path> <destination path>
+function copyFile {
+  cp $1 $2
+  chmod +x $2
+}
 
-echo "Disable Repos"
-sed -ie 's/enabled=1/enabled=0/g' /etc/yum.repos.d/CentOS-Base.repo
-sed -ie 's/enabled=1/enabled=0/g' /etc/yum.repos.d/epel.repo
+function enableRBDSR {
+  echo "Add RBDSR plugin to whitelist of SM plugins in /etc/xapi.conf"
+  grep "sm-plugins" /etc/xapi.conf
+  grep "sm-plugins" /etc/xapi.conf | grep -q "rbd" || sed -ie 's/sm-plugins\(.*\)/& rbd/g' /etc/xapi.conf
+  grep "sm-plugins" /etc/xapi.conf | grep "rbd"
+}
 
-echo "Installing files"
-cp bins/waitdmmerging.sh		/usr/bin
-chmod 755 /usr/bin/waitdmmerging.sh
-cp bins/ceph_plugin.py	/etc/xapi.d/plugins/ceph_plugin
-chmod +x /etc/xapi.d/plugins/ceph_plugin
+function disableRBDSR {
+  echo "Remove RBDSR plugin to whitelist of SM plugins in /etc/xapi.conf"
+  grep "sm-plugins" /etc/xapi.conf
+  grep "sm-plugins" /etc/xapi.conf | grep -q "rbd" || sed -ie 's/\(sm-plugins\)\(.*\)rbd\(.*\)/\1\2\3/g' /etc/xapi.conf
+  grep "sm-plugins" /etc/xapi.conf | grep "rbd"
+}
 
-cp bins/RBDSR.py		/opt/xensource/sm
-cp bins/cephutils.py	/opt/xensource/sm
-python -m compileall /opt/xensource/sm/RBDSR.py
-python -O -m compileall /opt/xensource/sm/RBDSR.py
-python -m compileall /opt/xensource/sm/cephutils.py
-python -O -m compileall /opt/xensource/sm/cephutils.py
-chmod +x /opt/xensource/sm/RBDSR.py
-chmod +x /opt/xensource/sm/cephutils.py
-ln -s /opt/xensource/sm/RBDSR.py /opt/xensource/sm/RBDSR
+function installEpel {
+  echo "Install Required Packages"
+  yum install -y epel-release  yum-plugin-priorities.noarch
+}
 
-if [ -e /sbin/tap-ctl-orig ]; then
-  echo "tap-ctl-orig already in place, not backing up!"
-else
-  mv /sbin/tap-ctl /sbin/tap-ctl-orig
+function installCeph {
+  echo "Install RBDSR depenencies"
+  yum install -y snappy leveldb gdisk python-argparse gperftools-libs fuse fuse-libs ceph-common rbd-fuse rbd-nbd
+}
+
+function installFiles {
+  echo "Install RBDSR Files"
+  copyFile "bins/waitdmmerging.sh"     "/usr/bin/waitdmmerging.sh"
+  copyFile "bins/ceph_plugin.py"	      "/etc/xapi.d/plugins/ceph_plugin"
+  copyFile "bins/RBDSR.py"             "/opt/xensource/sm/RBDSR"
+  copyFile "bins/cephutils.py"	        "/opt/xensource/sm/cephutils.py"
+
+  copyFile "bins/tap-ctl"              "/sbin/tap-ctl"
+  copyFile "bins/vhd-tool"             "/bin/vhd-tool"
+  copyFile "bins/sparse_dd"            "/usr/libexec/xapi/sparse_dd"
+
+  copyFile "bins/rbd2vhd.py"           "/bin/rbd2vhd"
+
+  ln "/bin/rbd2vhd" "/bin/vhd2rbd"
+  ln "/bin/rbd2vhd" "/bin/rbd2raw"
+  ln "/bin/rbd2vhd" "/bin/rbd2nbd"
+}
+
+function removeFiles {
+  echo "Removing RBDSR Files"
+  rm -f "/usr/bin/waitdmmerging.sh"
+  rm -f "/etc/xapi.d/plugins/ceph_plugin"
+  rm -f "/opt/xensource/sm/RBDSR"
+  rm -f "/opt/xensource/sm/cephutils.py"
+
+  rm -f "/sbin/tap-ctl"
+  rm -f "/bin/vhd-tool"
+  rm -f "/usr/libexec/xapi/sparse_dd"
+
+  rm -f "/bin/rbd2vhd"
+
+  rm -f "/bin/vhd2rbd"
+  rm -f "/bin/rbd2raw"
+  rm -f "/bin/rbd2nbd"
+}
+
+
+function install {
+  installRepo $1
+  setReposEnabled "CentOS-Base.repo" "base" 1
+  setReposEnabled "CentOS-Base.repo" "updates" 1
+  setReposEnabled "CentOS-Base.repo" "extras" 1
+  installEpel
+  setReposEnabled "epel.repo" "epel" 1
+  installCeph
+  setReposEnabled "CentOS-Base.repo" "base" 0
+  setReposEnabled "CentOS-Base.repo" "updates" 0
+  setReposEnabled "CentOS-Base.repo" "extras" 0
+  setReposEnabled "epel.repo" "epel" 0
+
+  backupFile "/sbin/tap-ctl"
+  backupFile "/bin/vhd-tool"
+  backupFile "/usr/libexec/xapi/sparse_dd"
+  backupFile "/etc/xapi.conf"
+
+  installFiles
+
+  enableRBDSR
+}
+
+function deinstall {
+  disableRBDSR
+  removeFiles
+  restoreFile "/sbin/tap-ctl"
+  restoreFile "/bin/vhd-tool"
+  restoreFile "/usr/libexec/xapi/sparse_dd"
+  restoreFile "/etc/xapi.conf"
+  deinstallRepo $1
+}
+
+if [ "$1" == "install"]; then
+  install $2
 fi
-if [ -e /bin/vhd-tool-orig ]; then
-  echo "/bin/vhd-tool-orig already in place, not backing up!"
-else
-  mv /bin/vhd-tool /bin/vhd-tool-orig
-fi
-if [ -e /usr/libexec/xapi/sparse_dd-orig ]; then
-  echo "/usr/libexec/xapi/sparse_dd-orig already in place, not backing up!"
-else
-  mv /usr/libexec/xapi/sparse_dd /usr/libexec/xapi/sparse_dd-orig
-fi
 
-cp bins/tap-ctl /sbin/tap-ctl
-cp bins/vhd-tool /bin/vhd-tool
-cp bins/sparse_dd /usr/libexec/xapi/sparse_dd
-chmod +x /sbin/tap-ctl
-chmod +x /bin/vhd-tool
-chmod +x /usr/libexec/xapi/sparse_dd
-cp bins/rbd2vhd.py /bin/rbd2vhd
-chmod +x /bin/rbd2vhd
-ln /bin/rbd2vhd /bin/vhd2rbd
-ln /bin/rbd2vhd /bin/rbd2raw
-ln /bin/rbd2vhd /bin/rbd2nbd
-
-echo "Add RBDSR plugin to whitelist of SM plugins in /etc/xapi.conf"
-cp /etc/xapi.conf /etc/xapi.conf.backup
-grep "sm-plugins" /etc/xapi.conf
-grep "sm-plugins" /etc/xapi.conf | grep -q "rbd" || sed -ie 's/sm-plugins\(.*\)/& rbd/g' /etc/xapi.conf
-grep "sm-plugins" /etc/xapi.conf | grep "rbd"
+if [ "$1" == "deinstall"]; then
+  deinstall $2
+fi

--- a/netinstall.sh
+++ b/netinstall.sh
@@ -11,5 +11,3 @@ wget "$REPO/$PROJECT/archive/$BRANCH.zip" -O ~/$PROJECT-temp.zip
 unzip ~/$PROJECT-temp.zip -d ~
 mv ~/$PROJECT-$BRANCH/ ~/$PROJECT/
 cd ~/$PROJECT/
-sh ./install.sh
-rm -rf ~/$PROJECT-temp.zip


### PR DESCRIPTION
…einstallation possible

I did not test this because I don't have a test pool. But the PR addresses some issues i ran into when using RDBSR: 
- running the netinstallation forces you to use the ceph version inside the github repository
- not being able to deinstall the RDBSR in case you messed up the installation in the first run

Hopefully someone can test it and it can be merged.