### PR TITLE
"Storage_interface.Vdi_does_not_exist" when scan

### DIFF
--- a/bins/RBDSR.py
+++ b/bins/RBDSR.py
@@ -137,13 +137,13 @@ class RBDSR(SR.SR, cephutils.SR):
                     else:
                         parent_vdi_ref = self.session.xenapi.VDI.get_by_uuid(parent_vdi_uuid)
                     self.session.xenapi.VDI.set_is_a_snapshot(vdi_ref, True)
-                    self.session.xenapi.VDI.set_name_description(vdi_ref, description)
                     self.session.xenapi.VDI.set_snapshot_of(vdi_ref, parent_vdi_ref)
                     if parent_vdi_info.has_key(RBDVDIs[vdi_uuid]['snapshot']):
                         self.session.xenapi.VDI.set_snapshot_time(vdi_ref, str(parent_vdi_info[RBDVDIs[vdi_uuid]['snapshot']]))
                     self.session.xenapi.VDI.set_read_only(vdi_ref, True)
                     self.session.xenapi.VDI.remove_from_sm_config(vdi_ref, 'snapshot-of')
                     self.session.xenapi.VDI.add_to_sm_config(vdi_ref, 'snapshot-of', parent_vdi_uuid)
+                    self.session.xenapi.VDI.set_name_description(vdi_ref, description)
             else:
                 vdi_info = self._get_vdi_info(vdi_uuid)
                 if vdi_info.has_key('VDI_LABEL'):

--- a/install_cn.sh
+++ b/install_cn.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+DEFAULT_CEPH_VERSION="jewel"
+CEPH_REPO="mirrors.163.com\/ceph"
+
+# Usage: installRepo <ceph-version>
+function installRepo {
+  echo "Install the release.asc key"
+  rpm --import 'https://download.ceph.com/keys/release.asc'
+  echo "Install new Repos"
+  cp -n repos/ceph-$1.repo /etc/yum.repos.d/
+  sed -i "s/download.ceph.com/$CEPH_REPO/g" /etc/yum.repos.d/ceph-$1.repo
+}
+
+function deinstallRepo {
+  echo "deinstallRepo $1"
+  rm -f /etc/yum.repos.d/ceph-$1.repo
+}
+
+# Usage: removeRepo <ceph-version>
+function removeRepo {
+  rm -f /etc/yum.repos.d/
+}
+
+# Usage: setReposEnabled <repo filename> <section name> <0|1>
+function setReposEnabled {
+  echo "Set $1 $2 enabled = $3"
+  sed -ie "/\[$2\]/,/^\[/s/enabled=[01]/enabled=$3/" /etc/yum.repos.d/$1
+}
+
+# Usage: backupFile <path>
+function backupFile {
+  echo "Backing Up file $1"
+  if [ -e $1-orig ]; then
+    echo "$1-orig already in place, not backing up!"
+  else
+    mv $1 $1-orig
+  fi
+}
+
+# Usage: copyFile <source path> <destination path>
+function copyFile {
+  cp $1 $2
+  chmod +x $2
+}
+
+function enableRBDSR {
+  echo "Add RBDSR plugin to whitelist of SM plugins in /etc/xapi.conf"
+  grep "sm-plugins" /etc/xapi.conf
+  grep "sm-plugins" /etc/xapi.conf | grep -q "rbd" || sed -ie 's/sm-plugins\(.*\)/& rbd/g' /etc/xapi.conf
+  grep "sm-plugins" /etc/xapi.conf | grep "rbd"
+}
+
+function disableRBDSR {
+  echo "Remove RBDSR plugin to whitelist of SM plugins in /etc/xapi.conf"
+  grep "sm-plugins" /etc/xapi.conf
+  grep "sm-plugins" /etc/xapi.conf | grep -q "rbd" || sed -ie 's/\(sm-plugins\)\(.*\)rbd\(.*\)/\1\2\3/g' /etc/xapi.conf
+  grep "sm-plugins" /etc/xapi.conf | grep "rbd"
+}
+
+function installEpel {
+  echo "Install Required Packages"
+  yum install -y epel-release  yum-plugin-priorities.noarch --enablerepo=base,extras --releasever=7
+}
+
+function installCeph {
+  echo "Install RBDSR depenencies"
+  yum install -y snappy leveldb gdisk python-argparse gperftools-libs fuse fuse-libs ceph-common rbd-fuse rbd-nbd --enablerepo=base,extras --releasever=7
+}
+
+function installFiles {
+  echo "Install RBDSR Files"
+  copyFile "bins/waitdmmerging.sh"      "/usr/bin/waitdmmerging.sh"
+  copyFile "bins/ceph_plugin.py"        "/etc/xapi.d/plugins/ceph_plugin"
+  copyFile "bins/RBDSR.py"              "/opt/xensource/sm/RBDSR"
+  copyFile "bins/cephutils.py"          "/opt/xensource/sm/cephutils.py"
+
+  copyFile "bins/tap-ctl"              "/sbin/tap-ctl"
+  copyFile "bins/vhd-tool"             "/bin/vhd-tool"
+  copyFile "bins/sparse_dd"            "/usr/libexec/xapi/sparse_dd"
+
+  copyFile "bins/rbd2vhd.py"           "/bin/rbd2vhd"
+
+  ln "/bin/rbd2vhd" "/bin/vhd2rbd"
+  ln "/bin/rbd2vhd" "/bin/rbd2raw"
+  ln "/bin/rbd2vhd" "/bin/rbd2nbd"
+}
+
+function removeFiles {
+  echo "Removing RBDSR Files"
+  rm -f "/usr/bin/waitdmmerging.sh"
+  rm -f "/etc/xapi.d/plugins/ceph_plugin"
+  rm -f "/opt/xensource/sm/RBDSR"
+  rm -f "/opt/xensource/sm/cephutils.py"
+
+  rm -f "/sbin/tap-ctl"
+  rm -f "/bin/vhd-tool"
+  rm -f "/usr/libexec/xapi/sparse_dd"
+
+  rm -f "/bin/rbd2vhd"
+
+  rm -f "/bin/vhd2rbd"
+  rm -f "/bin/rbd2raw"
+  rm -f "/bin/rbd2nbd"
+}
+
+
+function install {
+  installRepo $1
+  installEpel
+  installCeph
+
+  backupFile "/sbin/tap-ctl"
+  backupFile "/bin/vhd-tool"
+  backupFile "/usr/libexec/xapi/sparse_dd"
+
+  installFiles
+
+  enableRBDSR
+}
+
+function deinstall {
+  disableRBDSR
+  removeFiles
+  restoreFile "/sbin/tap-ctl"
+  restoreFile "/bin/vhd-tool"
+  restoreFile "/usr/libexec/xapi/sparse_dd"
+  restoreFile "/etc/xapi.conf"
+  deinstallRepo $1
+}
+
+case $1 in
+    update)
+  	yum update -y ceph-common rbd-fuse rbd-nbd --enablerepo=base,extras --releasever=7
+	;;
+    install)
+        if [ -z "$2" ]; then
+            install $DEFAULT_CEPH_VERSION
+        else
+            if [ -z `echo $2|egrep "^jewel$|^kraken$|^luminous$"` ]; then
+                echo "[ERROR]: Unsupported Ceph version specified '$2'"
+                exit 1
+            else
+                install $2
+            fi
+        fi
+        ;;
+    deinstall)
+        CEPH_INSTALLED_VERSION = `ls -1 | grep ceph | awk 'match($0, /ceph-(.*).repo/, a) {print a[1]}'`
+        if [ -z "$CEPH_INSTALLED_VERSION" ]; then
+            echo "[ERROR]: Can't determine installed version of Ceph."
+            echo "         RBDSR plugin is not installed or corrupted."
+            exit 2
+        fi
+        if [ -z "$2" ]; then
+            deinstall $CEPH_INSTALLED_VERSION
+        else
+            if [ "$2" != "$CEPH_INSTALLED_VERSION" ]; then
+                echo "[ERROR]: Installed version of Ceph is '$CEPH_INSTALLED_VERSION'"
+                exit 3
+            else
+                deinstall $2
+            fi
+        fi
+        ;;
+    *)
+        echo "Usage: $0 install|deinstall|update [jewel|kraken|luminous]"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
vdi snapshot may be change or deleted, so vdi update description must after set snapshot-of. Otherwise it may cause error "vdi_not_exists" when scaning

when setting description of vdi, the function will check the vdi's parent.
RBDSR.py line 673: `base_vdi_uuid = self_vdi_sm_config["snapshot-of"]`
in fact, the snapshot may be not exists.
