### PR TITLE
Fix mapping rbd in kernel mode

### DIFF
--- a/bins/ceph_plugin.py
+++ b/bins/ceph_plugin.py
@@ -70,7 +70,7 @@ def _map(session, arg_dict):
     vdi_name = arg_dict['vdi_name']
 
     if mode == "kernel":
-        dev = util.pread2(["rbd", "map", _vdi_name, "--pool", CEPH_POOL_NAME, "--name", CEPH_USER])
+        dev = util.pread2(["rbd", "map", _vdi_name, "--pool", CEPH_POOL_NAME, "--name", CEPH_USER]).rstrip('\n')
     elif mode == "fuse":
         pass
     elif mode == "nbd":


### PR DESCRIPTION
Mapping rbd disk in kernel mode failed with following error:
Mar 22 13:40:48 xen-r0102 SM: [3567] ['rbd', 'map', 'VHD-b8336f63-23a1-4ad7-9f02-a469d4a6b4a2', '--pool', 'RBD_XenStorage-d2141024-f13f-4db3-bb1f-b31c1bceaf2e', '--name', 'client.admin']
Mar 22 13:40:48 xen-r0102 SM: [3567]   pread SUCCESS
Mar 22 13:40:48 xen-r0102 SM: [3567] ['ln', '-s', '/dev/rbd0\n', '/run/sr-mount/d2141024-f13f-4db3-bb1f-b31c1bceaf2e/b8336f63-23a1-4ad7-9f02-a469d4a6b4a2']
Mar 22 13:40:48 xen-r0102 SM: [3567]   pread SUCCESS
Mar 22 13:40:48 xen-r0102 SM: [3451] Raising exception [46, The VDI is not available [opterr=Could not find: /run/sr-mount/d2141024-f13f-4db3-bb1f-b31c1bceaf2e/b8336f63-23a1-4ad7-9f02-a469d4a6b4a2]]
Mar 22 13:40:48 xen-r0102 SM: [3451] Exception in activate/attach
Mar 22 13:40:48 xen-r0102 SM: [3451] Removed host key host_OpaqueRef:f11bf82c-d477-529f-3c5c-8c4c06777132 for b8336f63-23a1-4ad7-9f02-a469d4a6b4a2
Mar 22 13:40:48 xen-r0102 SM: [3451] ***** BLKTAP2:<function _activate_locked at 0x1ee26e0>: EXCEPTION <class 'SR.SROSError'>, The VDI is not available [opterr=Could not find: /run/sr-mount/d2141024-f13f-4db3-bb1f-b31c1bceaf2e/b8336f63-23a1-4ad7-9f02-a469d4a6b4a2]

This patch removes '\n' from rbd device name
Tested on Xenserver 7.1 CU1 and ceph jewel 10.2.10
