### PR TITLE
fix issue with installing centos-release-ceph* repos

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -168,9 +168,9 @@ function removeFiles {
   }
 
 function install {
-  installRepo $1
   setReposEnabled "CentOS-Base.repo" "base" 1
   setReposEnabled "CentOS-Base.repo" "extras" 1
+  installRepo $1
   installCeph
   setReposEnabled "CentOS-Base.repo" "base" 0
   setReposEnabled "CentOS-Base.repo" "extras" 0


### PR DESCRIPTION
The repos cannot be installed while CentOS extras repository is disabled.